### PR TITLE
mkdir -p BUILD_DIR

### DIFF
--- a/tasks.sh
+++ b/tasks.sh
@@ -45,6 +45,7 @@ setup_yay() {
 }
 
 package() {
+	sudo -u ${BUILD_USER} mkdir -p "${BUILD_DIR}"
 	sudo -u ${BUILD_USER} yay -Sy --noconfirm --nopgpfetch --mflags "--skippgpcheck" --builddir "${BUILD_DIR}" "$@"
 }
 


### PR DESCRIPTION
Thanks for awesome repository.

Without builddir, my GitHub Actions failed to build.
I guess your GitHub Actions works correctly because you have cache of /tmp/build?