### PR TITLE
Fix pacman error: Unrecognized archive format

### DIFF
--- a/tasks.sh
+++ b/tasks.sh
@@ -63,6 +63,7 @@ repository() {
 	cd ${REPO_DIR}/${ARCH}
 	find ${BUILD_DIR} -name *.pkg.tar.zst -exec cp -f {} . \;
 	repo-add "${GITHUB_REPO_OWNER}.db.tar.gz" *.pkg.tar.zst
+	rename '.tar.gz' '' *.tar.gz	# repo-add originally creates links, this basically replaces them with the actual db archives
 }
 
 render_template() {


### PR DESCRIPTION
pacman tries to find the file '${db-name}.db' file, **but** which is a link after repo-add.
The .db and .files should be the archives themselves.

<img width="540" alt="image" src="https://user-images.githubusercontent.com/37269665/123700347-f9e55500-d87d-11eb-807a-beb0e4e9dd35.png">

rename provides a quick way to do this

<img width="648" alt="image" src="https://user-images.githubusercontent.com/37269665/123699899-69a71000-d87d-11eb-9a9b-cab06154d785.png">

> It was actually a error which i faced the first time i used this 😅